### PR TITLE
Use $(CC) instead of hardcoded gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: udooclient udooserver
 
 udooclient: udooclient.c
-	gcc -Wall udooclient.c -o udooclient
+	$(CC) -Wall udooclient.c -o udooclient
 
 udooserver: udooserver.c
-	gcc -Wall udooserver.c -o udooserver
+	$(CC) -Wall udooserver.c -o udooserver
 
 clean:
 	rm -rf udooclient udooserver


### PR DESCRIPTION
This simplifies cross-compilation and usage of compilers other than gcc